### PR TITLE
Individual persistence options labels and synchronizers

### DIFF
--- a/docs/persistent.md
+++ b/docs/persistent.md
@@ -16,3 +16,20 @@ be re-used in subsequent sentences.
 The labels and synchronizers may be cleared in Python code by calling the
 TwaddleRunner's `clear()` method. They may also be cleared in an interactive
 session with [the `clear` function](functions.md#clear).
+
+## Partially persistent modes
+
+In some cases it may be desirable to retain labels for use across multiple 
+sentences but not synchronizers, or vice versa. Label-only and synchronizer-only
+persistent modes are also available with the `persistent_labels` and
+`persistent_synchronizers` options on the TwaddleRunner. Setting the generic 
+`persistent` option to `True` forces persistence for both labels and synchronizers
+regardless of these parameters.
+
+### Label-only
+
+`runner = TwaddleRunner(<path_to_dictionaries>, persistent_labels=True)`
+
+### Synchronizer-only
+
+`runner = TwaddleRunner(<path_to_dictionaries>, persistent_synchronizers=True)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twaddle"
-version = "1.0.0"
+version = "1.1.0"
 description = "Text generation and templating"
 authors = [
     {name = "Chris Hengler",email = "chrysics@gmail.com"}

--- a/twaddle/lookup/lookup_manager.py
+++ b/twaddle/lookup/lookup_manager.py
@@ -18,8 +18,6 @@ class LookupManager:
             folder = Path(folder)
 
         for entry in folder.iterdir():
-            print(f"{type(entry)=}")
-            print(f"{entry.name=}")
             if entry.name.endswith(".dic") and entry.is_file():
                 new_dictionary = DictionaryFileParser.read_from_path(entry)
                 if new_dictionary is None:

--- a/twaddle/runner.py
+++ b/twaddle/runner.py
@@ -3,14 +3,26 @@ from twaddle.lookup.lookup_manager import LookupManager
 
 
 class TwaddleRunner:
-    def __init__(self, path: str, persistent: bool = False):
+    def __init__(
+        self,
+        path: str,
+        persistent: bool = False,
+        persistent_labels: bool = False,
+        persistent_synchronizers: bool = False,
+    ):
         self.lookup_manager = LookupManager()
         self.lookup_manager.add_dictionaries_from_folder(path)
-        self.interpreter = Interpreter(self.lookup_manager, persistent)
+        persistent_labels = True if persistent else persistent_labels
+        persistent_synchronizers = True if persistent else persistent_synchronizers
+        self.interpreter = Interpreter(
+            self.lookup_manager,
+            persistent_labels=persistent_labels,
+            persistent_synchronizers=persistent_synchronizers,
+        )
         pass
 
     def run_sentence(self, sentence: str) -> str:
         return self.interpreter.interpret_external(sentence)
 
     def clear(self) -> None:
-        self.interpreter.clear()
+        self.interpreter.force_clear()


### PR DESCRIPTION
Add `persistent_labels` and `persistent_synchronizers` options alongside the catch-all `persistent` mode.

Update docs and bump version for new release.