### PR TITLE
Error handling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python Debugger: Module",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "twaddle",
+            "args": ["../twaddle-dict"]
+        }
+    ]
+}

--- a/twaddle/__main__.py
+++ b/twaddle/__main__.py
@@ -1,6 +1,7 @@
 import readline  # noqa: F401
 import sys
 
+from twaddle.exceptions import TwaddleException
 from twaddle.runner import TwaddleRunner
 
 
@@ -18,6 +19,9 @@ def main():
         try:
             sentence = input(">")
             print(twaddle.run_sentence(sentence))
+        except TwaddleException as te:
+            print(f"Twaddle encountered an error:\n{te.message}")
+            twaddle.clear()
         except EOFError:
             quit()
 

--- a/twaddle/compiler/compiler.py
+++ b/twaddle/compiler/compiler.py
@@ -52,10 +52,12 @@ class Compiler:
         self.context = CompilerContextStack()
 
     def compile(self, sentence: str) -> RootObject:
+        self.context = CompilerContextStack()
         result = self.parse_root(lex(sentence))
         if self.context.current_context() is not CompilerContext.ROOT:
+            unexpected_context = self.context.current_context()
             raise TwaddleParserException(
-                f"[RantCompiler::compile] reached end while still in {self.context.current_context().name} context"
+                f"[RantCompiler::compile] reached end while still in {unexpected_context.name} context"
             )
         return result
 

--- a/twaddle/lookup/lookup_manager.py
+++ b/twaddle/lookup/lookup_manager.py
@@ -11,7 +11,11 @@ class LookupManager:
         self.dictionaries = dict[str, LookupDictionary]()
 
     def __getitem__(self, name: str) -> LookupDictionary:
-        return self.dictionaries[name]
+        if dictionary := self.dictionaries.get(name):
+            return dictionary
+        raise TwaddleDictionaryException(
+            f"[LookupManager.__getitem__] No dictionary loaded named {name}"
+        )
 
     def add_dictionaries_from_folder(self, folder: str | Path):
         if isinstance(folder, (str, Path)):


### PR DESCRIPTION
Improve error handling:

raise appropriate derived `TwaddleException`s when encountering non-existing dictionary or unexpected context at compilation end. 

Catch any `TwaddleException` encountered when running sentence in `__main__.py`