### PR TITLE
ensure we still return when encountering unexpected closing brackets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twaddle"
-version = "1.4.0"
+version = "1.5.0"
 description = "Text generation and templating"
 authors = [
     {name = "Chris Hengler",email = "chrysics@gmail.com"}

--- a/twaddle/compiler/compiler.py
+++ b/twaddle/compiler/compiler.py
@@ -93,6 +93,9 @@ class Compiler:
                 case TokenType.RIGHT_CURLY_BRACKET:
                     if context is CompilerContext.BLOCK:
                         return result
+                    raise TwaddleParserException(
+                        "[Compiler.parse_root] Unexpected right angle bracket"
+                    )
                 case TokenType.COLON:
                     if context is CompilerContext.FUNCTION:
                         return result
@@ -114,9 +117,15 @@ class Compiler:
                         return result
                     if context is CompilerContext.REGEX:
                         return result
+                    raise TwaddleParserException(
+                        "[Compiler.parse_root] Unexpected right square bracket"
+                    )
                 case TokenType.RIGHT_ANGLE_BRACKET:
                     if context is CompilerContext.LOOKUP:
                         return result
+                    raise TwaddleParserException(
+                        "[Compiler.parse_root] Unexpected right angle bracket"
+                    )
                 case TokenType.LOWER_INDEFINITE_ARTICLE:
                     result.append(IndefiniteArticleObject())
                     tokens.popleft()

--- a/twaddle/tests/compiler/test_compiler.py
+++ b/twaddle/tests/compiler/test_compiler.py
@@ -185,5 +185,15 @@ def test_strict_mode():
     assert lookup.strict_mode
 
 
+def test_raise_on_invalid_closing_brackets():
+    for bracket in ["]", ">", "}"]:
+        with pytest.raises(TwaddleParserException) as e_info:
+            get_standard_compile_result(bracket)
+        assert e_info.value is not None
+        with pytest.raises(TwaddleParserException) as e_info:
+            get_standard_compile_result("some text here" + bracket)
+        assert e_info.value is not None
+
+
 if __name__ == "__main__":
     test_parse_complex_regex()


### PR DESCRIPTION
`parse_root` didn't return when encountering an unexpected closing bracket (`]`, `>`, `}`), causing the compiler and everything downstream of it to hang.

Fix: Raise an exception on encountering the unexpected bracket.